### PR TITLE
Patching http_geo module to reload included file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Makefile
+objs/


### PR DESCRIPTION
Poll mtime of include file for changes

Example conf:
```bash
http {
  geo $request_tier {
    include /home/harish/request_tier_map.conf;
  }

  map $request_tier $tier_1_addr {
    default "";
    1 $binary_remote_addr;
  }

  limit_req_log_level info;
  limit_req_zone $tier_1_addr zone=req_zone_1:10m rate=1r/s;

  server {
    listen 443 ssl;
    limit_req zone=req_zone_1 burst=30;
  }
}

```